### PR TITLE
fix: use `rootDir` instead of `process.cwd()`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-e2e/
-.*
-*.log
-*.config.js

--- a/e2e/__fixtures__/docblock/concat.test.ts
+++ b/e2e/__fixtures__/docblock/concat.test.ts
@@ -1,5 +1,5 @@
 /**
- * @type ./concat.d.ts
+ * @type concat.d.ts
  */
 
 import { expectType } from 'mlh-tsd';

--- a/e2e/__snapshots__/docblock.test.ts.snap
+++ b/e2e/__snapshots__/docblock.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`reads \`@type\` comment in docblock 1`] = `
-"PASS e2e/__fixtures__/docblock/concat.test.ts
+"PASS ./concat.test.ts
   ✓
 Test Suites: 1 passed, 1 total
 Tests:       2 passed, 2 total

--- a/e2e/__snapshots__/failing.test.ts.snap
+++ b/e2e/__snapshots__/failing.test.ts.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`works with failing test 1`] = `
-"FAIL e2e/__fixtures__/failing/index.test.ts
+"FAIL ./index.test.ts
   ✓
-e2e/__fixtures__/failing/index.test.ts:5:19 - error - Argument of type 'number' is not assignable to parameter of type 'string'.
+index.test.ts:5:19 - error - Argument of type 'number' is not assignable to parameter of type 'string'.
 Test Suites: 1 failed, 1 total
 Tests:       1 failed, 1 passed, 2 total
 Snapshots:   0 total

--- a/e2e/__snapshots__/passing.test.ts.snap
+++ b/e2e/__snapshots__/passing.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`works with passing test 1`] = `
-"PASS e2e/__fixtures__/passing/index.test.ts
+"PASS ./index.test.ts
   ✓
 Test Suites: 1 passed, 1 total
 Tests:       2 passed, 2 total

--- a/e2e/__snapshots__/pkg-types.test.ts.snap
+++ b/e2e/__snapshots__/pkg-types.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`reads \`types\` property in package.json 1`] = `
-"PASS e2e/__fixtures__/pkg-types/types.test.ts
+"PASS ./types.test.ts
   ✓
 Test Suites: 1 passed, 1 total
 Tests:       2 passed, 2 total

--- a/package.json
+++ b/package.json
@@ -2,9 +2,12 @@
   "name": "jest-runner-tsd",
   "version": "1.1.0",
   "description": "A Jest runner that tests typescript typings using tsd under the hood",
-  "main": "src/index.js",
   "license": "MIT",
   "repository": "https://github.com/jest-community/jest-runner-tsd.git",
+  "main": "src/index.js",
+  "files": [
+    "src"
+  ],
   "contributors": [
     "Karan Sanjeev Nair <yo@alphaman.me> (https://alphaman.me)",
     "Saurabh Agarwala <saur.agarwala@gmail.com>"


### PR DESCRIPTION
The `cwd` options must be set to projects’ `rootDir` not hardcoded using `process.cwd()`.

This was the bug which was failing the test suite if `files` option was present in `package.json`. `process.cwd()` was pointing `tsd` to read that `package.json`. It must read the ones present in each test suite / project instead. `rootDir` makes it all work properly.