### PR TITLE
feat: pretty errors

### DIFF
--- a/e2e/__snapshots__/docblock.test.ts.snap
+++ b/e2e/__snapshots__/docblock.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`reads \`@type\` comment in docblock 1`] = `
 "PASS ./concat.test.ts
-  ✓
+  ✓ tsd typecheck
 Test Suites: 1 passed, 1 total
 Tests:       2 passed, 2 total
 Snapshots:   0 total

--- a/e2e/__snapshots__/failing.test.ts.snap
+++ b/e2e/__snapshots__/failing.test.ts.snap
@@ -2,8 +2,11 @@
 
 exports[`works with failing test 1`] = `
 "FAIL ./index.test.ts
-  ✓
-index.test.ts:5:19 - error - Argument of type 'number' is not assignable to parameter of type 'string'.
+  ✕ tsd typecheck
+  ● tsd typecheck
+    > 5 | expectType<string>(concat(1, 2));
+        |                    ^
+      index.test.ts:5:20 - error - Argument of type 'number' is not assignable to parameter of type 'string'.
 Test Suites: 1 failed, 1 total
 Tests:       1 failed, 1 passed, 2 total
 Snapshots:   0 total

--- a/e2e/__snapshots__/passing.test.ts.snap
+++ b/e2e/__snapshots__/passing.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`works with passing test 1`] = `
 "PASS ./index.test.ts
-  ✓
+  ✓ tsd typecheck
 Test Suites: 1 passed, 1 total
 Tests:       2 passed, 2 total
 Snapshots:   0 total

--- a/e2e/__snapshots__/pkg-types.test.ts.snap
+++ b/e2e/__snapshots__/pkg-types.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`reads \`types\` property in package.json 1`] = `
 "PASS ./types.test.ts
-  ✓
+  ✓ tsd typecheck
 Test Suites: 1 passed, 1 total
 Tests:       2 passed, 2 total
 Snapshots:   0 total

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "test": "jest"
   },
   "dependencies": {
+    "@babel/code-frame": "^7.15.8",
+    "chalk": "^4.1.2",
     "create-jest-runner": "^0.9.0",
     "graceful-fs": "^4.2.8",
     "jest-docblock": "^27.0.6",

--- a/src/fail.js
+++ b/src/fail.js
@@ -19,9 +19,8 @@ module.exports.fail = ({
 
   return toTestResult({
     stats,
-    title: 'Type Checks',
-    errorMessage: errorMessage.join('\n'),
-    tests: [{ duration: end - start, ...test }],
+    errorMessage,
+    tests: [{ duration: end - start, ...test, errorMessage }],
     jestTestPath: test.path,
   });
 };

--- a/src/formatErrorMessage.js
+++ b/src/formatErrorMessage.js
@@ -1,0 +1,50 @@
+const { codeFrameColumns } = require('@babel/code-frame');
+const chalk = require('chalk');
+
+const TITLE_BULLET = '\u25cf ';
+const TITLE_INDENT = '  ';
+const CODE_INDENT = '    ';
+const MESSAGE_INDENT = '      ';
+
+const NOT_EMPTY_LINE_REGEXP = /^(?!$)/gm;
+
+/**
+ * @param {string} lines
+ * @param {string} indent
+ */
+const indentAllLines = (lines, indent) =>
+  lines.replace(NOT_EMPTY_LINE_REGEXP, indent);
+
+module.exports = (diagnostics, testFile, fileContents) => {
+  const title =
+    chalk.bold.red(TITLE_INDENT + TITLE_BULLET + 'tsd typecheck') + '\n';
+
+  const messages = [];
+
+  diagnostics.forEach(error => {
+    const { column, line, message, severity } = error;
+
+    const codeFrame = codeFrameColumns(
+      fileContents,
+      { start: { column: column + 1, line } },
+      { highlightCode: true, linesAbove: 0, linesBelow: 0 }
+    );
+
+    const fileLocationSeverityMessage =
+      chalk.cyan(testFile) +
+      chalk.dim(':' + line + ':' + (column + 1)) +
+      ' - ' +
+      chalk.red.bold(severity) +
+      ' - ' +
+      message +
+      '\n';
+
+    messages.push(
+      indentAllLines(codeFrame, CODE_INDENT) +
+        '\n' +
+        indentAllLines(fileLocationSeverityMessage, MESSAGE_INDENT)
+    );
+  });
+
+  return title + '\n' + messages.join('\n\n');
+};

--- a/src/run.js
+++ b/src/run.js
@@ -2,15 +2,17 @@ const { dirname, join, posix, relative, sep } = require('path');
 const { readFileSync } = require('graceful-fs');
 const { parse } = require('jest-docblock');
 const tsd = require('mlh-tsd');
+const formatErrorMessage = require('./formatErrorMessage');
 const { pass } = require('./pass');
 const { fail } = require('./fail');
 
+const TEST_TITLE = 'tsd typecheck';
+
 /**
- * @param {string} rootDir
  * @param {string} testFile
+ * @param {string} fileContents
  */
-function resolveTypingsFile(rootDir, testFile) {
-  const fileContents = readFileSync(join(rootDir, testFile), 'utf8');
+function resolveTypingsFile(testFile, fileContents) {
   let { type } = parse(fileContents);
 
   if (Array.isArray(type)) {
@@ -30,8 +32,10 @@ function resolveTypingsFile(rootDir, testFile) {
 const normalizeSlashes = input => input.split(sep).join(posix.sep);
 
 module.exports = async ({ config: { rootDir }, testPath }) => {
+  const testFileContents = readFileSync(testPath, 'utf8');
+
   const testFile = relative(rootDir, testPath);
-  const typingsFile = resolveTypingsFile(rootDir, testFile);
+  const typingsFile = resolveTypingsFile(testFile, testFileContents);
 
   const start = Date.now();
 
@@ -46,23 +50,17 @@ module.exports = async ({ config: { rootDir }, testPath }) => {
   const numFailed = diagnostics.length;
   const numPassed = numTests - numFailed;
 
-  if (numFailed > 0) {
-    let errorMessage = [];
-
-    diagnostics.forEach(test => {
-      errorMessage.push(
-        `${normalizeSlashes(testFile)}:${test.line}:${test.column} - ${
-          test.severity
-        } - ${test.message}`
-      );
-    });
+  if (diagnostics.length > 0) {
+    const errorMessage = formatErrorMessage(
+      diagnostics,
+      normalizeSlashes(testFile),
+      testFileContents
+    );
 
     return fail({
       start,
       end,
-      test: {
-        path: testFile,
-      },
+      test: { path: testFile, title: TEST_TITLE },
       numFailed,
       numPassed,
       errorMessage,
@@ -73,8 +71,6 @@ module.exports = async ({ config: { rootDir }, testPath }) => {
     start,
     end,
     numPassed,
-    test: {
-      path: testFile,
-    },
+    test: { path: testFile, title: TEST_TITLE },
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2452,7 +2452,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -4374,12 +4374,14 @@ fsevents@^2.3.2:
   version: 0.0.0-use.local
   resolution: "jest-runner-tsd@workspace:."
   dependencies:
+    "@babel/code-frame": ^7.15.8
     "@babel/core": ^7.15.8
     "@babel/preset-env": ^7.15.8
     "@babel/preset-typescript": ^7.15.0
     "@typescript-eslint/eslint-plugin": ^4.33.0
     "@typescript-eslint/parser": ^4.33.0
     babel-jest: ^27.2.5
+    chalk: ^4.1.2
     create-jest-runner: ^0.9.0
     eslint: ^7.32.0
     eslint-config-prettier: ^8.3.0


### PR DESCRIPTION
Before:
<img width="761" alt="Screenshot 2021-10-21 at 17 10 29" src="https://user-images.githubusercontent.com/72159681/138295309-5a08e126-8cb3-4052-8757-26150950c867.png">

After:
<img width="802" alt="Screenshot 2021-10-21 at 17 06 57" src="https://user-images.githubusercontent.com/72159681/138295342-f083f52c-c7b3-4157-ba53-061cf44ad637.png">

Larger code frames looked unnecessary. For instance, most of the assertions in the Jest test suite are one-liners. Also `tsc` reporter is printing only one line of code. Seemed to be reasonable. Can be improved later if there is a need.