### PR TITLE
fix: avoid returning `failureMessages: [undefined]`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,4 @@
 module.exports = {
-  projects: [
-    {
-      displayName: 'e2e',
-      testMatch: ['<rootDir>/e2e/*.test.ts'],
-    },
-  ],
+  testMatch: ['<rootDir>/**/__tests__/*.test.ts', '<rootDir>/e2e/*.test.ts'],
   testTimeout: 30000,
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  reporters: ['default', 'github-actions'],
   testMatch: ['<rootDir>/**/__tests__/*.test.ts', '<rootDir>/e2e/*.test.ts'],
   testTimeout: 30000,
 };

--- a/src/__tests__/__snapshots__/fail.test.ts.snap
+++ b/src/__tests__/__snapshots__/fail.test.ts.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fails 1`] = `
+Object {
+  "console": null,
+  "failureMessage": "  ● tsd typecheck
+
+  Argument of type 'number' is not assignable to parameter of type 'string'.
+
+  > 5 | expectType<string>(concat(1, 2));
+      | ^
+
+    at e2e/__fixtures__/js-failing/index.test.ts:5:1",
+  "numFailingTests": 1,
+  "numPassingTests": 3,
+  "numPendingTests": 0,
+  "numTodoTests": 0,
+  "perfStats": Object {
+    "end": 1200,
+    "start": 0,
+  },
+  "skipped": undefined,
+  "snapshot": Object {
+    "added": 0,
+    "fileDeleted": false,
+    "matched": 0,
+    "unchecked": 0,
+    "unmatched": 0,
+    "updated": 0,
+  },
+  "sourceMaps": Object {},
+  "testExecError": null,
+  "testFilePath": "/path/to/e2e/__fixtures__/js-failing/index.test.ts",
+  "testResults": Array [
+    Object {
+      "ancestorTitles": Array [],
+      "duration": 1200,
+      "failureMessages": Array [
+        "  ● tsd typecheck
+
+  Argument of type 'number' is not assignable to parameter of type 'string'.
+
+  > 5 | expectType<string>(concat(1, 2));
+      | ^
+
+    at e2e/__fixtures__/js-failing/index.test.ts:5:1",
+      ],
+      "fullName": undefined,
+      "numPassingAsserts": 1,
+      "status": "failed",
+      "title": "tsd typecheck",
+    },
+  ],
+}
+`;

--- a/src/__tests__/__snapshots__/pass.test.ts.snap
+++ b/src/__tests__/__snapshots__/pass.test.ts.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pass 1`] = `
+Object {
+  "console": null,
+  "failureMessage": undefined,
+  "numFailingTests": 0,
+  "numPassingTests": 5,
+  "numPendingTests": 0,
+  "numTodoTests": 0,
+  "perfStats": Object {
+    "end": 1200,
+    "start": 0,
+  },
+  "skipped": undefined,
+  "snapshot": Object {
+    "added": 0,
+    "fileDeleted": false,
+    "matched": 0,
+    "unchecked": 0,
+    "unmatched": 0,
+    "updated": 0,
+  },
+  "sourceMaps": Object {},
+  "testExecError": null,
+  "testFilePath": "/path/to/e2e/__fixtures__/js-passing/index.test.ts",
+  "testResults": Array [
+    Object {
+      "ancestorTitles": Array [],
+      "duration": 1200,
+      "failureMessages": Array [],
+      "fullName": undefined,
+      "numPassingAsserts": 0,
+      "status": "passed",
+      "title": "tsd typecheck",
+    },
+  ],
+}
+`;

--- a/src/__tests__/fail.test.ts
+++ b/src/__tests__/fail.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@jest/globals';
+import { fail } from '../fail';
+
+const errorMessage = `  ● tsd typecheck
+
+  Argument of type 'number' is not assignable to parameter of type 'string'.
+
+  > 5 | expectType<string>(concat(1, 2));
+      | ^
+
+    at e2e/__fixtures__/js-failing/index.test.ts:5:1`;
+
+test('fails', () => {
+  const testResult = fail({
+    start: 0,
+    end: 1200,
+    test: {
+      path: '/path/to/e2e/__fixtures__/js-failing/index.test.ts',
+      title: 'tsd typecheck',
+    },
+    errorMessage,
+    numFailed: 1,
+    numPassed: 3,
+  });
+
+  expect(testResult).toMatchSnapshot();
+});

--- a/src/__tests__/pass.test.ts
+++ b/src/__tests__/pass.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@jest/globals';
+import { pass } from '../pass';
+
+test('pass', () => {
+  const testResult = pass({
+    start: 0,
+    end: 1200,
+    test: {
+      path: '/path/to/e2e/__fixtures__/js-passing/index.test.ts',
+      title: 'tsd typecheck',
+    },
+    numPassed: 5,
+  });
+
+  expect(testResult).toMatchSnapshot();
+});

--- a/src/toTestResult.js
+++ b/src/toTestResult.js
@@ -32,7 +32,7 @@ module.exports.toTestResult = ({
       return {
         ancestorTitles: [],
         duration: test.duration,
-        failureMessages: [test.errorMessage],
+        failureMessages: test.errorMessage ? [test.errorMessage] : [],
         fullName: test.testPath,
         numPassingAsserts: test.errorMessage ? 1 : 0,
         status: test.errorMessage ? 'failed' : 'passed',


### PR DESCRIPTION
From https://github.com/facebook/jest/pull/12839#issuecomment-1125770341

Fixing the logic to avoid returning `failureMessages: [undefined]`. The type of `failureMessage` is `Array<string>`, here implementation was incorrect.

For instance, all is good in `create-jest-runner`, because of types – https://github.com/jest-community/create-jest-runner/blob/69558d1bb03cfd3b9080ef7b8714ba17ff3c48cb/lib/toTestResult.ts#L56

Might be useful to have more type safety in this library, but to add a  build step is somewhat too much. Or?