### PR TITLE
refactor: add `tsc` typecheck

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - next
   pull_request:
     branches:
       - main
+      - next
 
 jobs:
   prepare-yarn-cache:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,12 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
       - uses: actions/setup-node@v3
         with:
           node-version: lts/*
           cache: yarn
-
       - name: Validate cache
         run: yarn
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,14 +1,12 @@
-name: Unit tests
+name: Node CI
 
 on:
   push:
     branches:
       - main
-      - next
   pull_request:
     branches:
       - main
-      - next
 
 jobs:
   prepare-yarn-cache:
@@ -40,6 +38,20 @@ jobs:
       - name: run ESLint
         run: yarn lint
 
+  typecheck:
+    needs: prepare-yarn-cache
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+          cache: yarn
+      - name: install
+        run: yarn
+      - name: run tsc
+        run: yarn tsc
+
   test-node:
     name: Test on Node.js v${{ matrix.node-version }}
     needs: prepare-yarn-cache
@@ -56,8 +68,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
-      - name:
-          install
+      - name: install
         run: yarn
       - name: run tests
         run: yarn test

--- a/package.json
+++ b/package.json
@@ -32,14 +32,16 @@
   "dependencies": {
     "@babel/code-frame": "^7.15.8",
     "chalk": "^4.1.2",
-    "create-jest-runner": "^0.11.0",
-    "tsd-lite": "^0.5.0"
+    "create-jest-runner": "^0.11.1",
+    "tsd-lite": "^0.5.4"
   },
   "devDependencies": {
     "@babel/core": "^7.15.8",
     "@babel/preset-env": "^7.15.8",
     "@babel/preset-typescript": "^7.15.0",
+    "@jest/test-result": "^28.1.0",
     "@tsd/typescript": "~4.6.0",
+    "@types/babel__code-frame": "^7.0.3",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "babel-jest": "^28.0.0",

--- a/src/__tests__/__snapshots__/fail.test.ts.snap
+++ b/src/__tests__/__snapshots__/fail.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`fails 1`] = `
 Object {
-  "console": null,
   "failureMessage": "  ● tsd typecheck
 
   Argument of type 'number' is not assignable to parameter of type 'string'.
@@ -11,30 +10,34 @@ Object {
       | ^
 
     at e2e/__fixtures__/js-failing/index.test.ts:5:1",
+  "leaks": false,
   "numFailingTests": 1,
   "numPassingTests": 3,
   "numPendingTests": 0,
   "numTodoTests": 0,
+  "openHandles": Array [],
   "perfStats": Object {
     "end": 1200,
+    "runtime": 1200,
+    "slow": false,
     "start": 0,
   },
-  "skipped": undefined,
+  "skipped": false,
   "snapshot": Object {
     "added": 0,
     "fileDeleted": false,
     "matched": 0,
     "unchecked": 0,
+    "uncheckedKeys": Array [],
     "unmatched": 0,
     "updated": 0,
   },
-  "sourceMaps": Object {},
-  "testExecError": null,
   "testFilePath": "/path/to/e2e/__fixtures__/js-failing/index.test.ts",
   "testResults": Array [
     Object {
       "ancestorTitles": Array [],
       "duration": 1200,
+      "failureDetails": Array [],
       "failureMessages": Array [
         "  ● tsd typecheck
 
@@ -45,7 +48,7 @@ Object {
 
     at e2e/__fixtures__/js-failing/index.test.ts:5:1",
       ],
-      "fullName": undefined,
+      "fullName": "/path/to/e2e/__fixtures__/js-failing/index.test.ts",
       "numPassingAsserts": 1,
       "status": "failed",
       "title": "tsd typecheck",

--- a/src/__tests__/__snapshots__/pass.test.ts.snap
+++ b/src/__tests__/__snapshots__/pass.test.ts.snap
@@ -2,34 +2,37 @@
 
 exports[`pass 1`] = `
 Object {
-  "console": null,
-  "failureMessage": undefined,
+  "failureMessage": null,
+  "leaks": false,
   "numFailingTests": 0,
   "numPassingTests": 5,
   "numPendingTests": 0,
   "numTodoTests": 0,
+  "openHandles": Array [],
   "perfStats": Object {
     "end": 1200,
+    "runtime": 1200,
+    "slow": false,
     "start": 0,
   },
-  "skipped": undefined,
+  "skipped": false,
   "snapshot": Object {
     "added": 0,
     "fileDeleted": false,
     "matched": 0,
     "unchecked": 0,
+    "uncheckedKeys": Array [],
     "unmatched": 0,
     "updated": 0,
   },
-  "sourceMaps": Object {},
-  "testExecError": null,
   "testFilePath": "/path/to/e2e/__fixtures__/js-passing/index.test.ts",
   "testResults": Array [
     Object {
       "ancestorTitles": Array [],
       "duration": 1200,
+      "failureDetails": Array [],
       "failureMessages": Array [],
-      "fullName": undefined,
+      "fullName": "/path/to/e2e/__fixtures__/js-passing/index.test.ts",
       "numPassingAsserts": 0,
       "status": "passed",
       "title": "tsd typecheck",

--- a/src/fail.js
+++ b/src/fail.js
@@ -1,5 +1,24 @@
 const { toTestResult } = require('./toTestResult');
 
+/**
+ * @typedef {object} Test
+ * @property {string} path
+ * @property {string} title
+ */
+
+/**
+ * @typedef {object} Options
+ * @property {number} start
+ * @property {number} end
+ * @property {Test} test
+ * @property {number} numFailed
+ * @property {number} numPassed
+ * @property {string=} errorMessage
+ */
+
+/**
+ * @param {Options} options
+ */
 module.exports.fail = ({
   start,
   end,
@@ -20,6 +39,7 @@ module.exports.fail = ({
   return toTestResult({
     stats,
     errorMessage,
+    skipped: false,
     tests: [{ duration: end - start, ...test, errorMessage }],
     jestTestPath: test.path,
   });

--- a/src/pass.js
+++ b/src/pass.js
@@ -1,15 +1,33 @@
 const { toTestResult } = require('./toTestResult');
 
+/**
+ * @typedef {object} Test
+ * @property {string} path
+ * @property {string} title
+ */
+
+/**
+ * @typedef {object} Options
+ * @property {number} start
+ * @property {number} end
+ * @property {Test} test
+ * @property {number} numPassed
+ */
+
+/**
+ * @param {Options} options
+ */
 module.exports.pass = ({ start, end, test, numPassed }) => {
   return toTestResult({
     stats: {
       failures: 0,
-      pending: 0,
       passes: numPassed,
+      pending: 0,
       todo: 0,
       start,
       end,
     },
+    skipped: false,
     tests: [{ duration: end - start, ...test }],
     jestTestPath: test.path,
   });

--- a/src/run.js
+++ b/src/run.js
@@ -5,6 +5,7 @@ const { pass } = require('./pass');
 
 const TEST_TITLE = 'tsd typecheck';
 
+/** @type {import('create-jest-runner').RunTest} */
 module.exports = ({ testPath }) => {
   const start = Date.now();
 
@@ -31,7 +32,7 @@ module.exports = ({ testPath }) => {
   return pass({
     start,
     end,
-    numPassed,
     test: { path: testPath, title: TEST_TITLE },
+    numPassed,
   });
 };

--- a/src/toTestResult.js
+++ b/src/toTestResult.js
@@ -1,3 +1,36 @@
+/** @typedef {import('@jest/test-result').TestResult} TestResult */
+
+/**
+ * @typedef {object} Stats
+ * @property {number} failures
+ * @property {number} passes
+ * @property {number} pending
+ * @property {number} todo
+ * @property {number} start
+ * @property {number} end
+ */
+
+/**
+ * @typedef {object} Test
+ * @property {number} duration
+ * @property {string} path
+ * @property {string=} errorMessage
+ * @property {string=} title
+ */
+
+/**
+ * @typedef {object} Options
+ * @property {Stats} stats
+ * @property {boolean} skipped
+ * @property {string=} errorMessage
+ * @property {Array<Test>} tests
+ * @property {string} jestTestPath
+ */
+
+/**
+ * @param {Options} options
+ * @returns {TestResult}
+ */
 module.exports.toTestResult = ({
   stats,
   skipped,
@@ -6,15 +39,18 @@ module.exports.toTestResult = ({
   jestTestPath,
 }) => {
   return {
-    console: null,
-    failureMessage: errorMessage,
+    failureMessage: errorMessage || null,
+    leaks: false,
     numFailingTests: stats.failures,
     numPassingTests: stats.passes,
     numPendingTests: stats.pending,
     numTodoTests: stats.todo,
+    openHandles: [],
     perfStats: {
-      end: new Date(stats.end).getTime(),
-      start: new Date(stats.start).getTime(),
+      end: stats.end,
+      start: stats.start,
+      runtime: stats.end - stats.start,
+      slow: false,
     },
     skipped,
     snapshot: {
@@ -22,18 +58,18 @@ module.exports.toTestResult = ({
       fileDeleted: false,
       matched: 0,
       unchecked: 0,
+      uncheckedKeys: [],
       unmatched: 0,
       updated: 0,
     },
-    sourceMaps: {},
-    testExecError: null,
     testFilePath: jestTestPath,
     testResults: tests.map(test => {
       return {
         ancestorTitles: [],
         duration: test.duration,
+        failureDetails: [],
         failureMessages: test.errorMessage ? [test.errorMessage] : [],
-        fullName: test.testPath,
+        fullName: test.path,
         numPassingAsserts: test.errorMessage ? 1 : 0,
         status: test.errorMessage ? 'failed' : 'passed',
         title: test.title || '',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es2021",
+
+    "allowUnreachableCode": false,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strict": true,
+
+    "isolatedModules": true,
+
+    "checkJs": true,
+    "noEmit": true,
+    "skipLibCheck": false
+  },
+  "include": ["./src/*.js"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1719,6 +1719,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/babel__code-frame@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "@types/babel__code-frame@npm:7.0.3"
+  checksum: 543bd933e5ffdfbf75dfee0a36461c8a9d9283d5a95ceae0e021b2aef7fe774f1f251ea56f507faedf9d3574894b4774636f2b125f5cc5f6759503e1e56feb93
+  languageName: node
+  linkType: hard
+
 "@types/babel__core@npm:^7.1.14":
   version: 7.1.19
   resolution: "@types/babel__core@npm:7.1.19"
@@ -2519,9 +2526,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"create-jest-runner@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "create-jest-runner@npm:0.11.0"
+"create-jest-runner@npm:^0.11.1":
+  version: 0.11.1
+  resolution: "create-jest-runner@npm:0.11.1"
   dependencies:
     chalk: ^4.1.0
     jest-worker: ^28.0.2
@@ -2536,7 +2543,7 @@ __metadata:
       optional: true
   bin:
     create-jest-runner: generator/index.js
-  checksum: 2ff2ff4f747c695a04c5ab3106b99a7bf4c6ddd567aad7af11d336a90105b2459ec1d31a6ac7b020ec32a0329843ea696e5706be8502e1c9fd5e50f21b099748
+  checksum: 6fc69d9fe3cd852155f73fbb423e834ba88e33d9f2f6f5bf76fbddc18ed54f73d3e037e83fe0c3f0a279b34f6b83555cd7a43557e20f58aa001c08fe5b3ccb0d
   languageName: node
   linkType: hard
 
@@ -3814,19 +3821,21 @@ __metadata:
     "@babel/core": ^7.15.8
     "@babel/preset-env": ^7.15.8
     "@babel/preset-typescript": ^7.15.0
+    "@jest/test-result": ^28.1.0
     "@tsd/typescript": ~4.6.0
+    "@types/babel__code-frame": ^7.0.3
     "@typescript-eslint/eslint-plugin": ^5.0.0
     "@typescript-eslint/parser": ^5.0.0
     babel-jest: ^28.0.0
     chalk: ^4.1.2
-    create-jest-runner: ^0.11.0
+    create-jest-runner: ^0.11.1
     eslint: ^8.0.0
     eslint-config-prettier: ^8.3.0
     eslint-plugin-prettier: ^4.0.0
     execa: ^5.1.1
     jest: ^28.0.0
     prettier: ^2.4.1
-    tsd-lite: ^0.5.0
+    tsd-lite: ^0.5.4
     typescript: ~4.6.0
   peerDependencies:
     "@tsd/typescript": ^3.8.3 || ^4.0.7
@@ -5190,12 +5199,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsd-lite@npm:^0.5.0":
-  version: 0.5.3
-  resolution: "tsd-lite@npm:0.5.3"
+"tsd-lite@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "tsd-lite@npm:0.5.4"
   peerDependencies:
     "@tsd/typescript": ^3.8.3 || ^4.0.7
-  checksum: b1a5ffcd584b66e34173f0182d4cc7b2c5a145655346f9014318dd16a7ab3418d462df1cfa13923f79628e7900e5b8992c1210f59492adc9b7ef242b2026ab14
+  checksum: d1777bd7292c9b56d4bcaab5bd73d64106a84067e76e1e836d7f5b89b84b9d123d35a13f9805d77480b237de68a14003eabdf45ad0d4db1b7c217a70d3dbbb59
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
As discussed, adding TSDoc types and `tsc` typecheck to CI. Few minor issues surfaced.

Good form now, but it feels like the code has to be reworked more. For instance, it would be nice to support `slowTestThreshold` option.