### PR TITLE
refactor: use typed jest globals

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -49,8 +49,8 @@ jobs:
           cache: yarn
       - name: install
         run: yarn
-      - name: run tsc
-        run: yarn tsc
+      - name: run typecheck
+        run: yarn typecheck
 
   test-node:
     name: Test on Node.js v${{ matrix.node-version }}

--- a/.yarn/patches/jest-npm-28.1.0-3beb54c0f4.patch
+++ b/.yarn/patches/jest-npm-28.1.0-3beb54c0f4.patch
@@ -1,0 +1,48 @@
+diff --git a/build/index.d.ts b/build/index.d.ts
+index 312362e37bacea5650ff99f8cb8d2b95d90fe862..424af1ac1f4d2485875a4facd4993a26ea51580a 100644
+--- a/build/index.d.ts
++++ b/build/index.d.ts
+@@ -4,20 +4,26 @@
+  * This source code is licensed under the MIT license found in the
+  * LICENSE file in the root directory of this source tree.
+  */
+-import {createTestScheduler} from '@jest/core';
+-import {getVersion} from '@jest/core';
+-import {run} from 'jest-cli';
+-import {runCLI} from '@jest/core';
+-import {SearchSource} from '@jest/core';
+-
+-export {createTestScheduler};
+-
+-export {getVersion};
+-
+-export {run};
+-
+-export {runCLI};
+-
+-export {SearchSource};
+-
+-export {};
++export {
++  SearchSource,
++  createTestScheduler,
++  getVersion,
++  runCLI,
++} from "@jest/core";
++export { run } from "jest-cli";
++declare global {
++  const beforeEach: typeof import("@jest/globals")["beforeEach"];
++  const beforeAll: typeof import("@jest/globals")["beforeAll"];
++  const afterEach: typeof import("@jest/globals")["afterEach"];
++  const afterAll: typeof import("@jest/globals")["afterAll"];
++  const describe: typeof import("@jest/globals")["describe"];
++  const fdescribe: typeof import("@jest/globals")["fdescribe"];
++  const xdescribe: typeof import("@jest/globals")["xdescribe"];
++  const test: typeof import("@jest/globals")["test"];
++  const xtest: typeof import("@jest/globals")["xtest"];
++  const it: typeof import("@jest/globals")["it"];
++  const fit: typeof import("@jest/globals")["fit"];
++  const xit: typeof import("@jest/globals")["xit"];
++  const expect: typeof import("@jest/globals")["expect"];
++  const jest: typeof import("@jest/globals")["jest"];
++}

--- a/e2e/__fixtures__/override-tsconfig/tsconfig.json
+++ b/e2e/__fixtures__/override-tsconfig/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "strict": false
   },

--- a/e2e/__fixtures__/tsconfig.json
+++ b/e2e/__fixtures__/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": true
+  },
+  "include": ["**/*"]
+}

--- a/e2e/errors.test.ts
+++ b/e2e/errors.test.ts
@@ -1,4 +1,3 @@
-import { expect, test } from '@jest/globals';
 import runJest from './runJest';
 
 test('throws if syntax error is encountered', async () => {

--- a/e2e/failing.test.ts
+++ b/e2e/failing.test.ts
@@ -1,4 +1,3 @@
-import { expect, test } from '@jest/globals';
 import runJest from './runJest';
 
 test('works with failing JS test', async () => {

--- a/e2e/override.test.ts
+++ b/e2e/override.test.ts
@@ -1,4 +1,3 @@
-import { expect, test } from '@jest/globals';
 import runJest from './runJest';
 
 test('overrides "strict": true in tsconfig', async () => {

--- a/e2e/passing.test.ts
+++ b/e2e/passing.test.ts
@@ -1,4 +1,3 @@
-import { expect, test } from '@jest/globals';
 import runJest from './runJest';
 
 test('works with passing JS test', async () => {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   ],
   "scripts": {
     "lint": "eslint .",
-    "test": "jest"
+    "test": "jest",
+    "typecheck": "yarn tsc && yarn tsc -p e2e && yarn tsc -p src/__tests__"
   },
   "dependencies": {
     "@babel/code-frame": "^7.15.8",
@@ -49,7 +50,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "execa": "^5.1.1",
-    "jest": "^28.0.0",
+    "jest": "^28.1.0",
     "prettier": "^2.4.1",
     "typescript": "~4.6.0"
   },
@@ -60,5 +61,8 @@
     "arrowParens": "avoid",
     "singleQuote": true
   },
-  "packageManager": "yarn@3.2.1"
+  "packageManager": "yarn@3.2.1",
+  "resolutions": {
+    "jest@^28.1.0": "patch:jest@npm:28.1.0#.yarn/patches/jest-npm-28.1.0-3beb54c0f4.patch"
+  }
 }

--- a/src/__tests__/runTest.test.ts
+++ b/src/__tests__/runTest.test.ts
@@ -1,11 +1,3 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  jest,
-  test,
-} from '@jest/globals';
 import type { RunTestOptions } from 'create-jest-runner';
 import tsdLite, { type TsdResult } from 'tsd-lite';
 import type ts from 'typescript';
@@ -13,9 +5,9 @@ import { formatTsdResults } from '../formatter';
 import runTest from '../run';
 
 jest.mock('tsd-lite');
-jest.mock('../formatter.js');
-
-jest.mocked(formatTsdResults).mockReturnValue('<mocked failure message>');
+jest.mock('../formatter.js', () => ({
+  formatTsdResults: jest.fn().mockReturnValue('<mocked failure message>'),
+}));
 
 beforeEach(() => {
   jest.spyOn(Date, 'now').mockReturnValueOnce(1000).mockReturnValueOnce(2800);

--- a/src/__tests__/tsconfig.json
+++ b/src/__tests__/tsconfig.json
@@ -1,10 +1,9 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "esModuleInterop": true,
     "skipLibCheck": true,
     "types": ["jest"]
   },
-  "include": ["**/*"],
-  "exclude": ["__fixtures__"]
+  "include": ["**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es2021",
+    "target": "es2019",
 
     "allowUnreachableCode": false,
     "exactOptionalPropertyTypes": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3833,7 +3833,7 @@ __metadata:
     eslint-config-prettier: ^8.3.0
     eslint-plugin-prettier: ^4.0.0
     execa: ^5.1.1
-    jest: ^28.0.0
+    jest: ^28.1.0
     prettier: ^2.4.1
     tsd-lite: ^0.5.4
     typescript: ~4.6.0
@@ -3987,7 +3987,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest@npm:^28.0.0":
+"jest@npm:28.1.0":
   version: 28.1.0
   resolution: "jest@npm:28.1.0"
   dependencies:
@@ -4002,6 +4002,24 @@ __metadata:
   bin:
     jest: bin/jest.js
   checksum: f025164c408cf5ddb6e74dac1e8cbaf94c1c31dd1c67aba4ceee5989b2d8a77886db8ed1fb88853b45cf194b14cd802b454bbbe6b278a1e2140250297dc100d3
+  languageName: node
+  linkType: hard
+
+"jest@patch:jest@npm:28.1.0#.yarn/patches/jest-npm-28.1.0-3beb54c0f4.patch::locator=jest-runner-tsd%40workspace%3A.":
+  version: 28.1.0
+  resolution: "jest@patch:jest@npm%3A28.1.0#.yarn/patches/jest-npm-28.1.0-3beb54c0f4.patch::version=28.1.0&hash=ec3d21&locator=jest-runner-tsd%40workspace%3A."
+  dependencies:
+    "@jest/core": ^28.1.0
+    import-local: ^3.0.2
+    jest-cli: ^28.1.0
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    jest: bin/jest.js
+  checksum: 0741ee4fd366da519a90482a9eb27823c5ba643465febceea90f21e6511557b0c981b7c80f34a153aa4261ce7ad3f1dd98fba28296ec5ff6b1275b3f710d964a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Using a patch to play with https://github.com/facebook/jest/pull/12856. This is a small library mixing JS/TS, so a good playground.

Observations:

1. The most notable difference from `@types/jest` is that just installing `@types/jest` makes types of globals available everywhere. If test files live inside `__tests__` directories, to be precise one should opt-out in source directories through `"types": []`.

1. In contrary, just installing `jest` does not make types available. One has to opt-in adding `tsconfig.json` with `"types": ["jest"]` in `__tests__` directories. If I get it right, this would disable other globals coming from `@types/*`, e.g. Node typings.

1. If test files live next to source (not in separate directories), it is harder to be precise with any opt-ins / opt-outs. In case of `jest` types, `tsconfig.json` needs `"types": ["jest", "node"]`.

1. If we have JS library, installing `@jest/types` or `jest` makes typings of globals available in all files. With `tsconfig.json` added, one has to opt-in for `jest` types, but `@jest/types` are still available globally.

---

Also I reworked type checks to include files of e2e and unit tests. Somehow missed it before.