### PR TITLE
fix: drop Node 12 and 17 support

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Jest 29 does not support Node 12 and 17. Time to drop the support here too?