### PR TITLE
chore(deps)!: bump `tsd-lite`

### DIFF
--- a/e2e/__snapshots__/failing.test.ts.snap
+++ b/e2e/__snapshots__/failing.test.ts.snap
@@ -4,7 +4,7 @@ exports[`works with failing JS test 1`] = `
 "FAIL e2e/__fixtures__/js-failing/index.test.ts
   ✕ tsd typecheck
   ● tsd typecheck
-    Argument of type 'number' is not assignable to parameter of type 'string'.
+    Parameter type 'string' is not identical to argument type 'number'.
     > 5 | expectType<string>(concat(1, 2));
         | ^
       at e2e/__fixtures__/js-failing/index.test.ts:5:1
@@ -20,7 +20,7 @@ exports[`works with failing TS test 1`] = `
 "FAIL e2e/__fixtures__/ts-failing/index.test.ts
   ✕ tsd typecheck
   ● tsd typecheck
-    Argument of type 'Date' is not assignable to parameter of type 'string'.
+    Parameter type 'string' is not identical to argument type 'Date'.
     > 5 | expectType<string>(makeDate(5, 5, 5));
         | ^
       at e2e/__fixtures__/ts-failing/index.test.ts:5:1

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@babel/code-frame": "^7.15.8",
     "chalk": "^4.1.2",
     "create-jest-runner": "^0.12.0",
-    "tsd-lite": "^0.6.0"
+    "tsd-lite": "^0.7.0"
   },
   "devDependencies": {
     "@babel/core": "^7.15.8",
@@ -56,7 +56,7 @@
     "typescript": "~4.9.0"
   },
   "peerDependencies": {
-    "@tsd/typescript": "^3.8.3 || ^4.0.7"
+    "@tsd/typescript": "4.x || 5.x"
   },
   "prettier": {
     "arrowParens": "avoid",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3888,10 +3888,10 @@ __metadata:
     execa: ^5.1.1
     jest: ^29.1.0
     prettier: ^2.4.1
-    tsd-lite: ^0.6.0
+    tsd-lite: ^0.7.0
     typescript: ~4.9.0
   peerDependencies:
-    "@tsd/typescript": ^3.8.3 || ^4.0.7
+    "@tsd/typescript": 4.x || 5.x
   languageName: unknown
   linkType: soft
 
@@ -5242,12 +5242,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsd-lite@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "tsd-lite@npm:0.6.0"
+"tsd-lite@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "tsd-lite@npm:0.7.0"
   peerDependencies:
-    "@tsd/typescript": ^3.8.3 || ^4.0.7
-  checksum: 7b603092411b9bf940b350475a741ffa6c5f3aa15e723a55d30069a47d25cecbedd4172740d8b894e08688500ec826f7d82a6252ea49e9fbd483c85199e662f0
+    "@tsd/typescript": 4.x || 5.x
+  checksum: 97e304de0bdc906377b213c662b48543fea7e8393f884bc1136d1b9cd731b304bdfefd513d5874b4b9c961fb6462ee40320297c38ec16b7921d0504616dd4c7f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #151

Just released `tsd-lite` v0.7.0, so upgrading it here.

**Breaking change:** support for `@tsd/typescript` v3.x is dropped and support for v5.x is added.

I did some clean up of error message, but that is just UX thingy.