### PR TITLE
chore(ci): test on Node.js v20

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x, 18.x, 19.x]
+        node-version: [14.x, 16.x, 18.x, 19.x, 20.x]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Run CI tests on Node.js v20.