### PR TITLE
chore!: drop support for Node.js v14 and v19

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x, 18.x, 19.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
     runs-on: ubuntu-latest
 
     steps:

--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
     "arrowParens": "avoid",
     "singleQuote": true
   },
-  "packageManager": "yarn@3.6.0"
+  "packageManager": "yarn@3.6.0",
+  "engines": {
+    "node": ">=16"
+  }
 }


### PR DESCRIPTION
The latest version of `tsd-lite` dropped support of Node.js v14 and v19. These are EOL versions. I think it makes sense to do the same here before upgrading `tsd-lite` (see #174).

In a way everything still works on Node.js v14. This is more like an attempt to keep things fresh.