### PR TITLE
chore: use `@tsconfig/node16`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@babel/preset-env": "^7.15.8",
     "@babel/preset-typescript": "^7.15.0",
     "@jest/test-result": "^29.1.0",
-    "@tsconfig/node14": "^14.0.0",
+    "@tsconfig/node16": "^16.1.0",
     "@tsd/typescript": "~5.1.0",
     "@types/babel__code-frame": "^7.0.3",
     "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "allowUnreachableCode": false,
     "exactOptionalPropertyTypes": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1866,10 +1866,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node14@npm:^14.0.0":
-  version: 14.1.0
-  resolution: "@tsconfig/node14@npm:14.1.0"
-  checksum: 8342dc30edbfaed11d1659b1a9819779bb69df210974a9e8a337b0624b1d9f5026f37e2dcc1d555adb3e4246a0ec35896b3ae5fe3fc69f3382d3bc11069cecc1
+"@tsconfig/node16@npm:^16.1.0":
+  version: 16.1.0
+  resolution: "@tsconfig/node16@npm:16.1.0"
+  checksum: a0a176492e3802a5340eda1e61eabc8d4767e46496bc080ce9c381993ce8c5fb3df8f65267c3a9af4335bc00a85028845f795ea27545f63d62b93ab6675cf8fa
   languageName: node
   linkType: hard
 
@@ -4013,7 +4013,7 @@ __metadata:
     "@babel/preset-env": ^7.15.8
     "@babel/preset-typescript": ^7.15.0
     "@jest/test-result": ^29.1.0
-    "@tsconfig/node14": ^14.0.0
+    "@tsconfig/node16": ^16.1.0
     "@tsd/typescript": ~5.1.0
     "@types/babel__code-frame": ^7.0.3
     "@typescript-eslint/eslint-plugin": ^6.0.0


### PR DESCRIPTION
Since the lowest supported is Node.js v16, we should use `@tsconfig/node16`. Forgot to upgrade it.