### PR TITLE
chore: deprecate `jest-runner-tsd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # `jest-runner-tsd`
 
-> Run your TypeScript type tests using Jest.
+> DEPRECATED: Please migrate to TSTyche: https://github.com/tstyche/tstyche
+
+Run your TypeScript type tests using Jest.
 
 [![version](https://img.shields.io/npm/v/jest-runner-tsd.svg)](https://npmjs.com/package/jest-runner-tsd)
 [![license](https://img.shields.io/github/license/jest-community/jest-runner-tsd.svg)](https://github.com/jest-community/jest-runner-tsd/blob/main/LICENSE.md)


### PR DESCRIPTION
I think it is time to deprecate `jest-runner-tsd` and encourage people to migrate.

---

TSTyche has different API and that might complicate the migration. But it is worth extra effort, because TSTyche can do more:

- it has more matchers;
- `test()` and `describe()` helpers;
- can test on different versions of TypeScript;
- easier to setup;
- less to install (only one package, which is only 200kb),
- and more.

---

`tsd-lite` is deprecated and I do not plan coming back to it. Reasons are mentioned above (;

An alternative could be to wait for necessary APIs exposed directly from `tsd`. They were planing to do so in https://github.com/tsdjs/tsd/issues/196. That plan is nearly one year old. So far nothing related with code changes have been done. Also note that in the future they plan to publish `tsd` as ESM only package. That might cause another trouble with integration.
